### PR TITLE
Display images in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,33 @@
 3. Usage of the Svelte logo must not give the impression or implication that the Svelte project (or any contributor to the project) is sponsoring or endorsing any other project, service, product or organization.
 
 4. Usage of the Svelte logo, to indicate, imply or assert compatibility or operability with the Svelte library, must be accurate and done in good faith.
+
+## Images
+
+<center>
+    
+    svelte-logo.png
+
+![Svelte Logo](./svelte-logo.png)
+
+    svelte-horizontal.png
+
+![Svelte horizontal](./svelte-horizontal.png)
+
+    svelte-vertical.png
+
+![Svelte vertical](./svelte-vertical.png)
+
+    svelte-logo-square.png
+
+![Svelte logo-square](./svelte-logo-square.png)
+
+    svelte-logotype.png
+
+![Svelte logotype](./svelte-logotype.png)
+
+    svelte-logo-cutout.svg
+
+![Svelte logo-cutout](./svelte-logo-cutout.svg)
+
+</center>


### PR DESCRIPTION
This makes in easier to see what the images look like with an extra click or downloading in the case of an svg.